### PR TITLE
Start virtual display if DISPLAY not set

### DIFF
--- a/boot_repair.py
+++ b/boot_repair.py
@@ -76,6 +76,16 @@ logging.basicConfig(
 logger = logging.getLogger("boot_repair_automation")
 logger.debug("Logger initialized successfully.")
 
+# Start a virtual display if no DISPLAY environment variable is present
+display = None
+if not os.environ.get("DISPLAY"):
+    try:
+        display = Display()
+        display.start()
+        logger.debug("Started virtual X display for headless environment.")
+    except Exception as e:
+        logger.warning(f"Failed to start virtual display: {e}")
+
 # -------------- LLM / DEEPSEEK SETUP --------------
 try:
     if LLM is not None:


### PR DESCRIPTION
## Summary
- handle headless environments by starting a pyvirtualdisplay before initializing the Tkinter UI

## Testing
- `python -m py_compile boot_repair.py`

------
https://chatgpt.com/codex/tasks/task_e_68746f248cb483308511c6d1c370e194