### PR TITLE
Document optional GPU requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ source .venv/bin/activate  # On Windows use .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+Only the core dependencies are installed this way. Optional GPU-intensive
+packages (such as `vllm`) are listed in `requirements-gpu.txt` and can be
+installed separately if needed:
+
+```bash
+pip install -r requirements-gpu.txt  # optional
+```
+
 The packages include `scikit-learn`, `transformers` and other heavy
 dependencies, so installation may take some time.
 

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,3 @@
+# Optional GPU-related packages
+vllm
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ python-dotenv
 pyvirtualdisplay
 openai
 transformers
-vllm


### PR DESCRIPTION
## Summary
- split optional GPU packages into `requirements-gpu.txt`
- point README users to the optional file during installation

## Testing
- `python -m py_compile app.py boot_repair.py`

------
https://chatgpt.com/codex/tasks/task_e_6874811511288330962a9a4e1576e5aa