### PR TITLE
Add confirmation before applying patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ python boot_repair.py --testmode
 `boot_repair.py` performs patch-based self modification. Unintended behavior can
 occur if a generated patch is faulty. Review the code and run it only on systems
 where potential changes and restarts are acceptable.
+Before a patch suggested by the language model is applied, the script shows the diff and asks for confirmation (`y`/`n`).

--- a/boot_repair.py
+++ b/boot_repair.py
@@ -6,7 +6,6 @@ import subprocess
 import shutil
 import asyncio
 import psutil
-import threading
 import ast
 from typing import Dict, Any
 import tkinter as tk
@@ -189,6 +188,12 @@ def propose_patch_changes(user_instructions: str, error_info: str = "") -> str:
     diff_text = query_deepseek(prompt)
     return diff_text
 
+def confirm_patch_application(diff_text: str) -> bool:
+    """Display the diff and ask the user to confirm applying it."""
+    print("Proposed patch:\n")
+    print(diff_text)
+    choice = input("Apply this patch? [y/N]: ").strip().lower()
+    return choice in ("y", "yes")
 
 def apply_patch_changes(diff_text: str) -> str:
     """
@@ -203,6 +208,10 @@ def apply_patch_changes(diff_text: str) -> str:
         msg = "The 'patch' command is required but not found. Please install it."
         logger.error(msg)
         return msg
+
+    if not confirm_patch_application(diff_text):
+        logger.info("Patch application cancelled by user.")
+        return "Patch application cancelled."
 
     # Read the current code lines
     try:


### PR DESCRIPTION
## Summary
- ask the user to confirm before applying a patch in `boot_repair.py`
- document patch confirmation in the README

## Testing
- `python -m py_compile boot_repair.py`
- `python boot_repair.py --testmode`

------
https://chatgpt.com/codex/tasks/task_e_68748694a85083309f24b40976052cc0