### PR TITLE
Add env var and system package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ pip install -r requirements-gpu.txt  # optional
 The packages include `scikit-learn`, `transformers` and other heavy
 dependencies, so installation may take some time.
 
+## Environment variables and system packages
+
+Some features require additional settings and packages.
+
+- `DEEPSEEK_API_KEY` must be defined so the assistant can access the language model. Export it before running the scripts:
+
+```bash
+export DEEPSEEK_API_KEY=your_token_here
+```
+
+- The utilities `patch`, `xdotool` and `Xvfb` must be installed. On Debian/Ubuntu systems run:
+
+```bash
+sudo apt-get install patch xdotool xvfb
+```
+
+On other distributions use the appropriate package manager such as `dnf` or `pacman`.
+
+
 ## Running the scripts
 
 ### `app.py`


### PR DESCRIPTION
## Summary
- document required environment variable `DEEPSEEK_API_KEY`
- list required system packages `patch`, `xdotool`, `Xvfb`
- show installation example for Debian/Ubuntu

## Testing
- `python -m py_compile app.py boot_repair.py`

------
https://chatgpt.com/codex/tasks/task_e_687497f34c688330ac9f52d902cab86a