### PR TITLE
Add voice interface and persistent chat memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ full repair loop:
 python boot_repair.py --testmode
 ```
 
+To enable experimental voice interaction, run with `--voice` (requires
+`SpeechRecognition` and `pyttsx3`):
+
+```bash
+python boot_repair.py --voice
+```
+
 ## Safety notice
 
 `boot_repair.py` performs patch-based self modification. Unintended behavior can

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+class ConversationMemory:
+    """Simple JSON-based persistent memory for chat history."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.history: List[Dict[str, str]] = []
+        self.load()
+
+    def load(self) -> None:
+        if self.path.exists():
+            try:
+                self.history = json.loads(self.path.read_text())
+            except Exception:
+                self.history = []
+
+    def append(self, role: str, content: str) -> None:
+        self.history.append({"role": role, "content": content})
+        self.history = self.history[-50:]
+        self.save()
+
+    def save(self) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(json.dumps(self.history))
+        except Exception:
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-dotenv
 pyvirtualdisplay
 openai
 transformers
+pyttsx3
+SpeechRecognition

--- a/voice_utils.py
+++ b/voice_utils.py
@@ -1,0 +1,26 @@
+import logging
+
+
+def speak(text: str) -> None:
+    """Speak text using pyttsx3 if available."""
+    try:
+        import pyttsx3
+        engine = pyttsx3.init()
+        engine.say(text)
+        engine.runAndWait()
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"TTS failed: {e}")
+
+
+def listen() -> str:
+    """Transcribe speech from the microphone using SpeechRecognition."""
+    try:
+        import speech_recognition as sr
+        r = sr.Recognizer()
+        with sr.Microphone() as source:
+            audio = r.listen(source)
+        # Using Google's free recognizer as a fallback
+        return r.recognize_google(audio)
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"Voice input failed: {e}")
+        return ""


### PR DESCRIPTION
## Summary
- add optional voice input/output via new `voice_utils`
- maintain chat history in `memory_utils` and load/save to `logs/chat_history.json`
- update `boot_repair.py` to support `--voice` flag and persistent memory
- document voice mode in README and add dependencies

## Testing
- `python -m py_compile app.py boot_repair.py memory_utils.py voice_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68745cbcbfe48330bfb2082191ac49c7