### PR TITLE
Fix worker skill discovery

### DIFF
--- a/layered_agent_full/worker/worker.py
+++ b/layered_agent_full/worker/worker.py
@@ -7,7 +7,7 @@ logging.basicConfig(filename=L/"worker.log",level=logging.INFO,format="%(asctime
 # helpers
 def discover():
     sk={}
-    for f in Path(__file__).parent/"skills".glob("*.py"):
+    for f in (Path(__file__).parent/"skills").glob("*.py"):
         if f.stem=="__init__":continue
         spec=importlib.util.spec_from_file_location(f.stem,f);m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
         for n,fn in inspect.getmembers(m,inspect.isfunction):


### PR DESCRIPTION
## Summary
- fix the path join in `discover()` so the worker can load skills

## Testing
- `python -m py_compile layered_agent_full/worker/worker.py`
- `python -m py_compile layered_agent_full/worker/bootstrap.py`
- `python layered_agent_full/worker/worker.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6874c06e274083309debdc50a8f828c7