### PR TITLE
Fix worker skill discovery path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# Agents Overview
+
+This document describes the distinct “agents” (components/microservices) in the **Jarvis-Like Layered Agent** architecture, their responsibilities, interfaces, and how they interoperate.
+
+## 1. Commander Agent
+
+**Role:** Central coordinator and chat interface.
+**Location:** `commander/server.py`
+
+### Responsibilities
+
+* Receives user chat requests (HTTP REST & WebSocket).
+* Invokes LLM (OpenAI or local) with function-calling schema.
+* Dispatches function calls to Worker Agents.
+* Records conversation history and function results.
+* Exposes `/status`, `/chat`, `/task`, `/register`, `/result` endpoints.
+
+### Key Modules
+
+* **`planning.py`**: Breaks user goals into schedulable subtasks.
+* **`status_ui/`**: React dashboard for real-time monitoring.
+* **`server.py`**: FastAPI application wiring everything together.
+
+## 2. Worker Agent
+
+**Role:** Executes individual skills on target machines.
+**Location:** `worker/worker.py`, `worker/bootstrap.py`
+
+### Responsibilities
+
+* Auto-discovers skill modules under `worker/skills/`.
+* Registers with Commander using bearer token.
+* Polls `/task/{worker_id}` for new tasks.
+* Executes skills (e.g., shell commands, diagnostics, sensor capture).
+* Posts encrypted results back to Commander.
+
+### Key Components
+
+* **`bootstrap.py`**: Creates venv, installs deps, launches worker.
+* **`skills/`**: Python modules decorated with `@skill`—`core.py`, `network.py`, `sensor.py`, etc.
+* **`sandbox.py`**: (Optional) Plugin isolation and validation.
+
+## 3. Planning Agent
+
+**Role:** High-level goal decomposition and scheduling.
+**Location:** `commander/planning.py`
+
+### Responsibilities
+
+* Receives abstract goals from Commander.
+* Uses simple LLM prompts or heuristics to split into steps.
+* Stores subtasks in SQLite DB with schedule timestamps.
+* Provides due tasks for automatic enqueueing.
+
+## 4. Memory Agent
+
+**Role:** Persistent conversation memory.
+**Location:** `memory.py`
+
+### Responsibilities
+
+* Stores chat history in Redis or local store.
+* Provides context to LLM calls (full dialogue or recent window).
+* Supports retrieval, summarization, and session management.
+
+## 5. Voice I/O Agent
+
+**Role:** Handles speech input/output.
+**Location:** `voice_io.py`, `tts.py`
+
+### Responsibilities
+
+* **Speech-to-Text**: Uses Whisper to transcribe audio files.
+* **Text-to-Speech**: Uses `pyttsx3` for voice responses.
+* Exposes functions to the Commander for seamless multimodal chat.
+
+## 6. Sensor Agent
+
+**Role:** Captures real-time environmental data.
+**Location:** `worker/skills/sensor.py`
+
+### Responsibilities
+
+* **Camera**: Grabs frames via OpenCV (`capture_image`).
+* **Microphone**: Records audio with `sounddevice` (`record_audio`).
+* Returns raw bytes or arrays for further processing by LLM or UI.
+
+## 7. Plugin Manager Agent
+
+**Role:** Dynamic plugin loading and version control.
+**Location:** `plugin_manager.py`, `worker/sandbox.py`
+
+### Responsibilities
+
+* Pulls new skill definitions from Git or URLs.
+* Validates and installs in isolated venv or container.
+* Updates skill registry in Worker Agent without full redeploy.
+
+## 8. Local Model Agent
+
+**Role:** Provides fallback LLM inference.
+**Location:** `models/local_model.py`
+
+### Responsibilities
+
+* Wraps local inference engines (e.g., llama.cpp).
+* Implements same `chat()` interface as OpenAI client.
+* Commander selects between local or API-based LLM at runtime.
+
+## 9. System-Health UI Agent
+
+**Role:** Web dashboard for monitoring.
+**Location:** `commander/status_ui/` React app
+
+### Responsibilities
+
+* Displays active Workers, queued tasks, and logs.
+* Streams sensor data (camera snapshots, audio clips).
+* Allows manual task enqueueing and plugin management.
+
+---
+
+**Extensibility:** Any new agent should conform to these patterns—define clear interfaces, register with the Commander’s schema, and expose tasks as function-calling endpoints.
+
+**Next Steps:** Validate each agent with unit tests, integrate end-to-end workflows, and secure with role-based access controls.

--- a/layered_agent_full/commander/planning.py
+++ b/layered_agent_full/commander/planning.py
@@ -4,8 +4,11 @@ Breaks high-level goals into scheduled tasks stored in a SQLite DB."""
 import sqlite3
 import uuid
 from datetime import datetime, timedelta
+from pathlib import Path
 
-DB_PATH = "./commander/tasks.db"
+# Store tasks database in the same directory as this module
+DB_PATH = Path(__file__).resolve().parent / "tasks.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
 class Planner:

--- a/layered_agent_full/commander/server.py
+++ b/layered_agent_full/commander/server.py
@@ -2,9 +2,9 @@ import os, toml, pathlib, uuid, json
 from fastapi import FastAPI, Body, HTTPException, UploadFile, File, Header, Response
 from pydantic import BaseModel
 import openai
-from shared.state import CommanderState
-from shared.protocol import ChatMessage, FunctionCall
-from shared.utils import aes_decrypt
+from layered_agent_full.shared.state import CommanderState
+from layered_agent_full.shared.protocol import ChatMessage, FunctionCall
+from layered_agent_full.shared.utils import aes_decrypt
 
 app = FastAPI()
 state = CommanderState()

--- a/layered_agent_full/requirements-minimal.txt
+++ b/layered_agent_full/requirements-minimal.txt
@@ -1,2 +1,4 @@
 openai>=1.14.3
 requests>=2.31.0
+toml>=0.10
+python-multipart>=0.0.6

--- a/layered_agent_full/requirements.txt
+++ b/layered_agent_full/requirements.txt
@@ -8,3 +8,5 @@ whisper @ git+https://github.com/openai/whisper.git
 cryptography>=42.0.5
 gitpython>=3.1.43
 partclone>=0.3.23 ; sys_platform != 'win32'
+toml>=0.10
+python-multipart>=0.0.6

--- a/layered_agent_full/shared/state.py
+++ b/layered_agent_full/shared/state.py
@@ -3,9 +3,12 @@ import json
 import secrets
 from datetime import datetime
 from typing import Dict, List, Any
-from shared.protocol import make_skill_schema, ChatMessage
+from pathlib import Path
+from layered_agent_full.shared.protocol import make_skill_schema, ChatMessage
 
-DB_PATH = './commander/tasks.db'
+# Use a path relative to this file so the DB is found regardless of CWD
+DB_PATH = Path(__file__).resolve().parent.parent / "commander" / "tasks.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
 class CommanderState:
@@ -86,7 +89,7 @@ class CommanderState:
 # Test cases for planning and shared modules
 if __name__ == '__main__':
     print('Testing shared.protocol.make_skill_schema...')
-    from shared.protocol import make_skill_schema, ChatMessage
+    from layered_agent_full.shared.protocol import make_skill_schema, ChatMessage
 
     schema = make_skill_schema([{'name': 'foo', 'description': 'desc', 'parameters': {}}])
     print('Schema:', schema)
@@ -94,7 +97,7 @@ if __name__ == '__main__':
     print('ChatMessage:', msg)
 
     print('\nTesting Planner...')
-    from commander.planning import Planner
+    from layered_agent_full.commander.planning import Planner
 
     planner = Planner()
     tid = planner.plan('Step one. Step two.')

--- a/layered_agent_full/worker/worker.py
+++ b/layered_agent_full/worker/worker.py
@@ -7,8 +7,8 @@ logging.basicConfig(filename=L/"worker.log",level=logging.INFO,format="%(asctime
 # helpers
 def discover():
     sk={}
-    # path join requires parentheses so glob runs on the full directory
-    for f in (Path(__file__).parent/"skills").glob("*.py"):
+    # ensure glob runs against the skills directory path
+    for f in (Path(__file__).parent / "skills").glob("*.py"):
         if f.stem=="__init__":continue
         spec=importlib.util.spec_from_file_location(f.stem,f);m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
         for n,fn in inspect.getmembers(m,inspect.isfunction):

--- a/layered_agent_full/worker/worker.py
+++ b/layered_agent_full/worker/worker.py
@@ -7,8 +7,7 @@ logging.basicConfig(filename=L/"worker.log",level=logging.INFO,format="%(asctime
 # helpers
 def discover():
     sk={}
-    # ensure glob runs against the skills directory path
-    for f in (Path(__file__).parent / "skills").glob("*.py"):
+    for f in (Path(__file__).parent/"skills").glob("*.py"):
         if f.stem=="__init__":continue
         spec=importlib.util.spec_from_file_location(f.stem,f);m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
         for n,fn in inspect.getmembers(m,inspect.isfunction):

--- a/layered_agent_full/worker/worker.py
+++ b/layered_agent_full/worker/worker.py
@@ -7,7 +7,8 @@ logging.basicConfig(filename=L/"worker.log",level=logging.INFO,format="%(asctime
 # helpers
 def discover():
     sk={}
-    for f in Path(__file__).parent/"skills".glob("*.py"):
+    # path join requires parentheses so glob runs on the full directory
+    for f in (Path(__file__).parent/"skills").glob("*.py"):
         if f.stem=="__init__":continue
         spec=importlib.util.spec_from_file_location(f.stem,f);m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
         for n,fn in inspect.getmembers(m,inspect.isfunction):


### PR DESCRIPTION
## Summary
- document all agents in AGENTS.md
- normalize database path handling in planning and state modules
- update commander server imports to use package paths
- add missing dependencies to requirements
- clarify skill discovery path in worker

## Testing
- `python -m py_compile layered_agent_full/worker/worker.py`
- `python -m py_compile layered_agent_full/worker/bootstrap.py`
- `OPENAI_API_KEY=dummy python -m layered_agent_full.commander.server --help`
- `python layered_agent_full/worker/worker.py --help`
- `python boot_repair.py --testmode`


------
https://chatgpt.com/codex/tasks/task_e_6874c06e274083309debdc50a8f828c7