### PR TITLE
Add pytest workflow and unit tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python Tests
+
+on:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r layered_agent_full/requirements-minimal.txt
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.shared import state as state_module
+import json
+
+
+def test_audit_records_event(tmp_path):
+    state_module.DB_PATH = tmp_path / "audit.db"
+    state_module.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    s = state_module.CommanderState()
+
+    s.audit("test", {"foo": "bar"})
+
+    cur = s.conn.cursor()
+    cur.execute("SELECT action, details FROM audit")
+    row = cur.fetchone()
+    assert row[0] == "test"
+    assert json.loads(row[1]) == {"foo": "bar"}

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.commander import planning
+
+
+def test_planner_plan(tmp_path):
+    planning.DB_PATH = tmp_path / "tasks.db"
+    planning.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    planner = planning.Planner()
+
+    tid = planner.plan("First task. Second task.")
+
+    cur = planner.conn.cursor()
+    cur.execute("SELECT id, description, scheduled_at FROM tasks ORDER BY scheduled_at")
+    rows = cur.fetchall()
+
+    assert len(rows) == 2
+    assert rows[0][1] == "First task"
+    assert rows[1][1] == "Second task"
+    assert tid == rows[0][0]
+    assert rows[0][2] < rows[1][2]

--- a/tests/test_worker_discover.py
+++ b/tests/test_worker_discover.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import types
+
+# ensure repository root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.worker.skills.core import run_shell
+
+
+def load_discover():
+    path = Path(__file__).resolve().parents[1] / 'layered_agent_full' / 'worker' / 'worker.py'
+    source = path.read_text()
+    pre = source.split('# main')[0]
+    mod = types.ModuleType('worker_partial')
+    mod.__dict__['__file__'] = str(path)
+    exec(pre, mod.__dict__)
+    return mod.discover
+
+
+def test_discover_finds_run_shell():
+    discover = load_discover()
+    skills = discover()
+    assert 'run_shell' in skills
+    assert skills['run_shell'].__name__ == run_shell.__name__


### PR DESCRIPTION
## Summary
- add Python test workflow running on pull requests
- test planner, audit, and worker skill discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875294ab25c8330b4809e820aa54806