### PR TITLE
Remove sys.path alteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,16 @@ On other distributions use the appropriate package manager such as `dnf` or `pac
 
 ## Running the scripts
 
+Run each entry point using ``python -m`` so that the project root
+is placed on ``PYTHONPATH`` automatically. This avoids modifying
+``sys.path`` in code.
+
 ### `app.py`
 
 Start the Flask server:
 
 ```bash
-python app.py
+python -m app
 ```
 
 The server listens on port 5000. Available endpoints:
@@ -76,21 +80,21 @@ issues. It also contains logic to modify and patch its own code. For safety run
 it inside a VM or other sandbox.
 
 ```bash
-python boot_repair.py
+python -m boot_repair
 ```
 
 You can pass `--testmode` to perform a quick start-up test without entering the
 full repair loop:
 
 ```bash
-python boot_repair.py --testmode
+python -m boot_repair --testmode
 ```
 
 To enable experimental voice interaction, run with `--voice` (requires
 `SpeechRecognition` and `pyttsx3`):
 
 ```bash
-python boot_repair.py --voice
+python -m boot_repair --voice
 ```
 
 ## Safety notice

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,6 @@
-"""Project root initializer."""
+"""Project package initialization."""
 
-import os
-import sys
-
-# Ensure project root is on PYTHONPATH so subpackages like 'shared' and
-# 'commander' can be imported when running scripts directly from this
-# repository.
-sys.path.insert(0, os.getcwd())
+# No explicit path modifications are necessary. Run scripts with
+# ``python -m`` so Python automatically adds the project root to
+# ``sys.path``.
 


### PR DESCRIPTION
## Summary
- drop manual `sys.path` editing from `__init__`
- document running modules with `python -m` in the README

## Testing
- `pip install -q requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752c097f208330b4b7a31cb03e9869