### PR TITLE
Fix docs for agent locations and optional deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,6 @@ This document describes the distinct “agents” (components/microservices) in 
 
 * **`bootstrap.py`**: Creates venv, installs deps, launches worker.
 * **`skills/`**: Python modules decorated with `@skill`—`core.py`, `network.py`, `sensor.py`, etc.
-* **`sandbox.py`**: (Optional) Plugin isolation and validation.
 
 ## 3. Planning Agent
 
@@ -85,18 +84,7 @@ This document describes the distinct “agents” (components/microservices) in 
 * **Microphone**: Records audio with `sounddevice` (`record_audio`).
 * Returns raw bytes or arrays for further processing by LLM or UI.
 
-## 7. Plugin Manager Agent
-
-**Role:** Dynamic plugin loading and version control.
-**Location:** _(not yet implemented)_
-
-### Responsibilities
-
-* Pulls new skill definitions from Git or URLs.
-* Validates and installs in isolated venv or container.
-* Updates skill registry in Worker Agent without full redeploy.
-
-## 8. Local Model Agent
+## 7. Local Model Agent
 
 **Role:** Provides fallback LLM inference.
 **Location:** `models/local_model.py`
@@ -107,7 +95,7 @@ This document describes the distinct “agents” (components/microservices) in 
 * Implements same `chat()` interface as OpenAI client.
 * Commander selects between local or API-based LLM at runtime.
 
-## 9. System-Health UI Agent
+## 8. System-Health UI Agent
 
 **Role:** Web dashboard for monitoring.
 **Location:** `commander/status_ui/` React app

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ pip install -r layered_agent_full/requirements.txt
 # or
 pip install -r layered_agent_full/requirements-minimal.txt
 ```
+Optional sensor features require extra packages that are not installed
+by default. Install them manually if needed:
+
+```bash
+pip install opencv-python sounddevice numpy
+```
 
 ### Starting the Commander
 


### PR DESCRIPTION
## Summary
- clean up worker docs
- document optional OpenCV, sounddevice, and numpy packages
- remove stale sandbox and plugin manager references

## Testing
- `pip install -r layered_agent_full/requirements-minimal.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687539e96edc8330b952a64966bcca10