### PR TITLE
Add plugin manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,8 @@ This document describes the distinct “agents” (components/microservices) in 
 
 * Displays active Workers, queued tasks, and logs.
 * Streams sensor data (camera snapshots, audio clips).
-* Allows manual task enqueueing and plugin management.
+* Allows manual task enqueueing and plugin management
+  (`layered_agent_full/plugin_manager.py`).
 
 ---
 

--- a/layered_agent_full/plugin_manager.py
+++ b/layered_agent_full/plugin_manager.py
@@ -1,0 +1,69 @@
+"""Plugin management utilities for Worker agents."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, Callable
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class PluginManager:
+    """Download and load skill plugins."""
+
+    def __init__(self, plugin_dir: Path | None = None):
+        self.plugin_dir = Path(plugin_dir or Path.home() / ".agent" / "plugins")
+        self.plugin_dir.mkdir(parents=True, exist_ok=True)
+        self.skills: Dict[str, Callable] = {}
+
+    def load_from_url(self, url: str) -> Path:
+        """Download a single Python module from ``url`` into ``plugin_dir``."""
+        fname = url.split("/")[-1]
+        if not fname.endswith(".py"):
+            raise ValueError("Only .py plugins supported")
+        dest = self.plugin_dir / fname
+        logger.info("Downloading plugin %s", url)
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        dest.write_bytes(resp.content)
+        return dest
+
+    def load_from_git(self, repo_url: str, subdir: str | None = None) -> Path:
+        """Clone ``repo_url`` and copy ``.py`` files to ``plugin_dir``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run([
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                repo_url,
+                tmp,
+            ], check=True)
+            src = Path(tmp)
+            if subdir:
+                src = src / subdir
+            for f in src.glob("*.py"):
+                (self.plugin_dir / f.name).write_bytes(f.read_bytes())
+        return self.plugin_dir
+
+    def discover_plugins(self) -> Dict[str, Callable]:
+        """Import all plugin modules and return discovered skills."""
+        skills: Dict[str, Callable] = {}
+        for f in self.plugin_dir.glob("*.py"):
+            if f.stem == "__init__":
+                continue
+            spec = importlib.util.spec_from_file_location(f.stem, f)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            for name, fn in inspect.getmembers(mod, inspect.isfunction):
+                if getattr(fn, "_is_skill", False):
+                    skills[name] = fn
+        self.skills = skills
+        return skills

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.plugin_manager import PluginManager
+
+# load refresh_skills from worker without executing main
+
+def load_refresh():
+    path = Path(__file__).resolve().parents[1] / 'layered_agent_full' / 'worker' / 'worker.py'
+    source = path.read_text()
+    pre = source.split('# main')[0]
+    mod = types.ModuleType('worker_partial')
+    mod.__dict__['__file__'] = str(path)
+    exec(pre, mod.__dict__)
+    return mod.refresh_skills, mod
+
+
+def test_plugin_loading(tmp_path):
+    plug_dir = tmp_path / 'plugins'
+    plug_dir.mkdir()
+    plugin_file = plug_dir / 'greet.py'
+    plugin_file.write_text(
+        "from layered_agent_full.worker.skills.core import skill\n\n" \
+        "@skill\n" \
+        "def greet(name: str):\n" \
+        "    return f'Hello {name}'\n"
+    )
+
+    pm = PluginManager(plugin_dir=plug_dir)
+    refresh_skills, mod = load_refresh()
+
+    refresh_skills(pm)
+    assert 'greet' in mod.skills
+    assert callable(mod.skills['greet'])


### PR DESCRIPTION
## Summary
- implement plugin management utilities
- enable workers to refresh skills from plugins
- document plugin manager path in AGENTS overview
- test plugin manager behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753c49857c833083cdf4dc8b2e6abd