### PR TITLE
Fix result endpoint when secrets missing

### DIFF
--- a/tests/test_server_result.py
+++ b/tests/test_server_result.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import json
+import importlib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.shared import state as state_module
+
+
+def test_post_result_without_secrets(tmp_path, monkeypatch):
+    # Redirect HOME so secrets.toml does not exist
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    # Use isolated database
+    state_module.DB_PATH = tmp_path / 'tasks.db'
+    state_module.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    # Provide OpenAI key so server import succeeds
+    monkeypatch.setenv('OPENAI_API_KEY', 'dummy')
+
+    server = importlib.reload(importlib.import_module('layered_agent_full.commander.server'))
+
+    tid = 't123'
+    payload = {'x': 1}
+    body = {'payload': json.dumps(payload)}
+
+    resp = server.post_result(tid, body=body, authorization=server.state.bearer_token)
+    assert resp == {'status': 'ok'}
+
+    msg = server.state.history[-1]
+    data = json.loads(msg.content)
+    assert data['task_id'] == tid
+    assert data['result'] == payload


### PR DESCRIPTION
## Summary
- make `/result/{task_id}` handle missing `secrets.toml`
- add regression test for the missing secrets case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753d7b1b9c8330bcf022bc8747cd78