### PR TITLE
Add FastAPI and planner unit tests

### DIFF
--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import importlib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from layered_agent_full.shared.protocol import FunctionCall
+from layered_agent_full.shared import state as state_module
+
+
+def test_worker_registration_and_queue(tmp_path, monkeypatch):
+    # isolate state DB
+    state_module.DB_PATH = tmp_path / "tasks.db"
+    state_module.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    server = importlib.reload(importlib.import_module("layered_agent_full.commander.server"))
+    client = TestClient(server.app)
+
+    payload = {"token": server.state.bearer_token, "worker_id": "w1", "skills": []}
+    resp = client.post("/register", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["worker_id"] == "w1"
+    assert "w1" in server.state.workers
+
+    server.state.enqueue("w1", FunctionCall(name="dummy", arguments={}))
+
+    resp = client.get(f"/task/w1", headers={"Authorization": server.state.bearer_token})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["tasks"]) == 1
+    assert data["tasks"][0]["function"]["name"] == "dummy"

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.commander import planning
+
+
+def test_task_insertion_and_retrieval(tmp_path):
+    planning.DB_PATH = tmp_path / "tasks.db"
+    planning.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    planner = planning.Planner()
+
+    tid = planner.plan("Single task.")
+
+    due = planner.fetch_due()
+    assert len(due) == 1
+    row = due[0]
+    assert row[0] == tid
+    assert row[2] == "Single task"
+
+    planner.mark_done(tid)
+    assert planner.fetch_due() == []


### PR DESCRIPTION
## Summary
- add planner test for inserting and fetching tasks
- add commander test using FastAPI TestClient for worker registration and queue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687540f128d88330b5d1a51c85c4918e