### PR TITLE
Fix worker discover package context

### DIFF
--- a/layered_agent_full/worker/worker.py
+++ b/layered_agent_full/worker/worker.py
@@ -9,8 +9,14 @@ logging.basicConfig(filename=L/"worker.log",level=logging.INFO,format="%(asctime
 def discover():
     sk={}
     for f in (Path(__file__).parent/"skills").glob("*.py"):
-        if f.stem=="__init__":continue
-        spec=importlib.util.spec_from_file_location(f.stem,f);m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+        if f.stem=="__init__":
+            continue
+        spec=importlib.util.spec_from_file_location(
+            "layered_agent_full.worker.skills." + f.stem,
+            f,
+        )
+        m=importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
         for n,fn in inspect.getmembers(m,inspect.isfunction):
             if getattr(fn,"_is_skill",False): sk[n]=fn
     return sk

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from layered_agent_full.worker.skills.core import run_shell
+
+
+def load_worker():
+    path = Path(__file__).resolve().parents[1] / 'layered_agent_full' / 'worker' / 'worker.py'
+    source = path.read_text()
+    pre = source.split('# main')[0]
+    mod = types.ModuleType('worker_partial')
+    mod.__dict__['__file__'] = str(path)
+    exec(pre, mod.__dict__)
+    return mod
+
+
+def test_discover_via_module():
+    worker = load_worker()
+    skills = worker.discover()
+    assert 'run_shell' in skills
+    assert skills['run_shell'].__name__ == run_shell.__name__


### PR DESCRIPTION
## Summary
- ensure worker skill discovery loads modules with correct package
- add regression test for worker.discover()

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687552630b308330bc8b48988085d63b