### PR TITLE
Update docs on network requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ pip install -r layered_agent_full/requirements.txt
 # or
 pip install -r layered_agent_full/requirements-minimal.txt
 ```
+The full requirements file installs optional packages such as
+`whisper` directly from GitHub. This step requires outbound network
+access. When network access is limited, use the minimal requirements or
+skip features that depend on those extras.
 Commander uses the `cryptography` package to encrypt worker results, so this
 dependency is included in the minimal requirements.
 Optional sensor features require extra packages that are not installed

--- a/layered_agent_full/README.md
+++ b/layered_agent_full/README.md
@@ -11,6 +11,10 @@ pip install -r requirements.txt
 # or for a slimmer set
 pip install -r requirements-minimal.txt
 ```
+Installing the full requirements fetches some packages from GitHub (for
+example the `whisper` repository), so it needs outbound network
+connectivity. If your environment restricts internet access, install the
+minimal requirements instead or skip those optional capabilities.
 
 Optional sensor features (camera, microphone) require extra packages:
 


### PR DESCRIPTION
## Summary
- mention outbound network access is needed to install `whisper` from GitHub
- suggest using `requirements-minimal.txt` when network access is limited

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687556b9c3b48330971574666584533e